### PR TITLE
Test constructors in typekit_scripting_test

### DIFF
--- a/eigen_typekit/package.xml
+++ b/eigen_typekit/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>eigen_typekit</name>
-  <version>2.8.0</version>
+  <version>2.8.1</version>
   <license>LGPL</license>
   <description>An Orocos typekit for Eigen types.</description>
   <maintainer email="orocos-dev@lists.mech.kuleuven.be">Orocos Developers</maintainer>

--- a/kdl_typekit/package.xml
+++ b/kdl_typekit/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>kdl_typekit</name>
-  <version>2.8.0</version>
+  <version>2.8.1</version>
   <description>This package contains the KDL RTT bindings</description>
   <maintainer email="orocos-dev@lists.mech.kuleuven.be">Orocos Developers</maintainer>
 

--- a/kdl_typekit/src/kdlTypekitChain.cpp
+++ b/kdl_typekit/src/kdlTypekitChain.cpp
@@ -1,5 +1,16 @@
 #include "kdlTypekit.hpp"
 
+template class RTT::internal::DataSource< ::KDL::Chain >;
+template class RTT::internal::AssignableDataSource< ::KDL::Chain >;
+template class RTT::internal::ValueDataSource< ::KDL::Chain >;
+template class RTT::internal::ConstantDataSource< ::KDL::Chain >;
+template class RTT::internal::ReferenceDataSource< ::KDL::Chain >;
+template class RTT::base::ChannelElement< ::KDL::Chain >;
+template class RTT::OutputPort< ::KDL::Chain >;
+template class RTT::InputPort< ::KDL::Chain >;
+template class RTT::Property< ::KDL::Chain >;
+template class RTT::Attribute< ::KDL::Chain >;
+
 namespace KDL{
   using namespace std;
   using namespace RTT;

--- a/kdl_typekit/src/kdlTypekitFrame.cpp
+++ b/kdl_typekit/src/kdlTypekitFrame.cpp
@@ -1,5 +1,26 @@
 #include "kdlTypekit.hpp"
 
+template class RTT::internal::DataSource< ::KDL::Frame >;
+template class RTT::internal::AssignableDataSource< ::KDL::Frame >;
+template class RTT::internal::ValueDataSource< ::KDL::Frame >;
+template class RTT::internal::ConstantDataSource< ::KDL::Frame >;
+template class RTT::internal::ReferenceDataSource< ::KDL::Frame >;
+template class RTT::base::ChannelElement< ::KDL::Frame >;
+template class RTT::OutputPort< ::KDL::Frame >;
+template class RTT::InputPort< ::KDL::Frame >;
+template class RTT::Property< ::KDL::Frame >;
+template class RTT::Attribute< ::KDL::Frame >;
+template class RTT::internal::DataSource< std::vector<KDL::Frame> >;
+template class RTT::internal::AssignableDataSource< std::vector<KDL::Frame> >;
+template class RTT::internal::ValueDataSource< std::vector<KDL::Frame> >;
+template class RTT::internal::ConstantDataSource< std::vector<KDL::Frame> >;
+template class RTT::internal::ReferenceDataSource< std::vector<KDL::Frame> >;
+template class RTT::base::ChannelElement< std::vector<KDL::Frame> >;
+template class RTT::OutputPort< std::vector<KDL::Frame> >;
+template class RTT::InputPort< std::vector<KDL::Frame> >;
+template class RTT::Property< std::vector<KDL::Frame> >;
+template class RTT::Attribute< std::vector<KDL::Frame> >;
+
 namespace KDL{
   using namespace std;
   using namespace RTT;

--- a/kdl_typekit/src/kdlTypekitJacobian.cpp
+++ b/kdl_typekit/src/kdlTypekitJacobian.cpp
@@ -1,5 +1,16 @@
 #include "kdlTypekit.hpp"
 
+template class RTT::internal::DataSource< ::KDL::Jacobian >;
+template class RTT::internal::AssignableDataSource< ::KDL::Jacobian >;
+template class RTT::internal::ValueDataSource< ::KDL::Jacobian >;
+template class RTT::internal::ConstantDataSource< ::KDL::Jacobian >;
+template class RTT::internal::ReferenceDataSource< ::KDL::Jacobian >;
+template class RTT::base::ChannelElement< ::KDL::Jacobian >;
+template class RTT::OutputPort< ::KDL::Jacobian >;
+template class RTT::InputPort< ::KDL::Jacobian >;
+template class RTT::Property< ::KDL::Jacobian >;
+template class RTT::Attribute< ::KDL::Jacobian >;
+
 namespace KDL{
   using namespace std;
   using namespace RTT;

--- a/kdl_typekit/src/kdlTypekitJntArray.cpp
+++ b/kdl_typekit/src/kdlTypekitJntArray.cpp
@@ -1,5 +1,17 @@
 #include "kdlTypekit.hpp"
 
+template class RTT::internal::DataSource< ::KDL::JntArray >;
+template class RTT::internal::AssignableDataSource< ::KDL::JntArray >;
+template class RTT::internal::ValueDataSource< ::KDL::JntArray >;
+template class RTT::internal::ConstantDataSource< ::KDL::JntArray >;
+template class RTT::internal::ReferenceDataSource< ::KDL::JntArray >;
+template class RTT::base::ChannelElement< ::KDL::JntArray >;
+template class RTT::OutputPort< ::KDL::JntArray >;
+template class RTT::InputPort< ::KDL::JntArray >;
+template class RTT::Property< ::KDL::JntArray >;
+template class RTT::Attribute< ::KDL::JntArray >;
+
+
 namespace KDL{
   using namespace std;
   using namespace RTT;

--- a/kdl_typekit/src/kdlTypekitJoint.cpp
+++ b/kdl_typekit/src/kdlTypekitJoint.cpp
@@ -1,5 +1,16 @@
 #include "kdlTypekit.hpp"
 
+template class RTT::internal::DataSource< ::KDL::Joint >;
+template class RTT::internal::AssignableDataSource< ::KDL::Joint >;
+template class RTT::internal::ValueDataSource< ::KDL::Joint >;
+template class RTT::internal::ConstantDataSource< ::KDL::Joint >;
+template class RTT::internal::ReferenceDataSource< ::KDL::Joint >;
+template class RTT::base::ChannelElement< ::KDL::Joint >;
+template class RTT::OutputPort< ::KDL::Joint >;
+template class RTT::InputPort< ::KDL::Joint >;
+template class RTT::Property< ::KDL::Joint >;
+template class RTT::Attribute< ::KDL::Joint >;
+
 namespace KDL{
   using namespace std;
   using namespace RTT;

--- a/kdl_typekit/src/kdlTypekitRotation.cpp
+++ b/kdl_typekit/src/kdlTypekitRotation.cpp
@@ -1,5 +1,26 @@
 #include "kdlTypekit.hpp"
 
+template class RTT::internal::DataSource< ::KDL::Rotation >;
+template class RTT::internal::AssignableDataSource< ::KDL::Rotation >;
+template class RTT::internal::ValueDataSource< ::KDL::Rotation >;
+template class RTT::internal::ConstantDataSource< ::KDL::Rotation >;
+template class RTT::internal::ReferenceDataSource< ::KDL::Rotation >;
+template class RTT::base::ChannelElement< ::KDL::Rotation >;
+template class RTT::OutputPort< ::KDL::Rotation >;
+template class RTT::InputPort< ::KDL::Rotation >;
+template class RTT::Property< ::KDL::Rotation >;
+template class RTT::Attribute< ::KDL::Rotation >;
+template class RTT::internal::DataSource< std::vector<KDL::Rotation> >;
+template class RTT::internal::AssignableDataSource< std::vector<KDL::Rotation> >;
+template class RTT::internal::ValueDataSource< std::vector<KDL::Rotation> >;
+template class RTT::internal::ConstantDataSource< std::vector<KDL::Rotation> >;
+template class RTT::internal::ReferenceDataSource< std::vector<KDL::Rotation> >;
+template class RTT::base::ChannelElement< std::vector<KDL::Rotation> >;
+template class RTT::OutputPort< std::vector<KDL::Rotation> >;
+template class RTT::InputPort< std::vector<KDL::Rotation> >;
+template class RTT::Property< std::vector<KDL::Rotation> >;
+template class RTT::Attribute< std::vector<KDL::Rotation> >;
+
 namespace KDL{
   using namespace std;
   using namespace RTT;

--- a/kdl_typekit/src/kdlTypekitSegment.cpp
+++ b/kdl_typekit/src/kdlTypekitSegment.cpp
@@ -1,5 +1,16 @@
 #include "kdlTypekit.hpp"
 
+template class RTT::internal::DataSource< ::KDL::Segment >;
+template class RTT::internal::AssignableDataSource< ::KDL::Segment >;
+template class RTT::internal::ValueDataSource< ::KDL::Segment >;
+template class RTT::internal::ConstantDataSource< ::KDL::Segment >;
+template class RTT::internal::ReferenceDataSource< ::KDL::Segment >;
+template class RTT::base::ChannelElement< ::KDL::Segment >;
+template class RTT::OutputPort< ::KDL::Segment >;
+template class RTT::InputPort< ::KDL::Segment >;
+template class RTT::Property< ::KDL::Segment >;
+template class RTT::Attribute< ::KDL::Segment >;
+
 namespace KDL{
   using namespace std;
   using namespace RTT;

--- a/kdl_typekit/src/kdlTypekitTwist.cpp
+++ b/kdl_typekit/src/kdlTypekitTwist.cpp
@@ -1,5 +1,26 @@
 #include "kdlTypekit.hpp"
 
+template class RTT::internal::DataSource< ::KDL::Twist >;
+template class RTT::internal::AssignableDataSource< ::KDL::Twist >;
+template class RTT::internal::ValueDataSource< ::KDL::Twist >;
+template class RTT::internal::ConstantDataSource< ::KDL::Twist >;
+template class RTT::internal::ReferenceDataSource< ::KDL::Twist >;
+template class RTT::base::ChannelElement< ::KDL::Twist >;
+template class RTT::OutputPort< ::KDL::Twist >;
+template class RTT::InputPort< ::KDL::Twist >;
+template class RTT::Property< ::KDL::Twist >;
+template class RTT::Attribute< ::KDL::Twist >;
+template class RTT::internal::DataSource< std::vector<KDL::Twist> >;
+template class RTT::internal::AssignableDataSource< std::vector<KDL::Twist> >;
+template class RTT::internal::ValueDataSource< std::vector<KDL::Twist> >;
+template class RTT::internal::ConstantDataSource< std::vector<KDL::Twist> >;
+template class RTT::internal::ReferenceDataSource< std::vector<KDL::Twist> >;
+template class RTT::base::ChannelElement< std::vector<KDL::Twist> >;
+template class RTT::OutputPort< std::vector<KDL::Twist> >;
+template class RTT::InputPort< std::vector<KDL::Twist> >;
+template class RTT::Property< std::vector<KDL::Twist> >;
+template class RTT::Attribute< std::vector<KDL::Twist> >;
+
 namespace KDL{
   using namespace std;
   using namespace RTT;

--- a/kdl_typekit/src/kdlTypekitTwist.cpp
+++ b/kdl_typekit/src/kdlTypekitTwist.cpp
@@ -5,7 +5,7 @@ namespace KDL{
   using namespace RTT;
 
   void loadTwistTypes(){
-    RTT::types::Types()->addType( new KDLTypeInfo<Twist>("KDL.Twist") );
+    RTT::types::Types()->addType( new KDLVectorTypeInfo<Twist,6>("KDL.Twist") );
     RTT::types::Types()->addType( new SequenceTypeInfo<std::vector< Twist > >("KDL.Twist[]") );
   };
 }  

--- a/kdl_typekit/src/kdlTypekitTypes.hpp
+++ b/kdl_typekit/src/kdlTypekitTypes.hpp
@@ -10,7 +10,6 @@
 #include <kdl/jntarray.hpp>
 
 
-
 // This is a hack. We include it unconditionally as it may be required by some
 // typekits *and* it is a standard header. Ideally, we would actually check if
 // some of the types need std::vector.
@@ -29,10 +28,13 @@
     extern template class RTT::internal::ConstantDataSource< ::KDL::Frame >;
     extern template class RTT::internal::ReferenceDataSource< ::KDL::Frame >;
 #endif
-#ifdef ORO_INPUT_PORT_HPP
-    extern template class RTT::OutputPort< ::KDL::Frame >;
+#ifdef ORO_CHANNEL_ELEMENT_HPP
+    extern template class RTT::base::ChannelElement< ::KDL::Frame >;
 #endif
 #ifdef ORO_OUTPUT_PORT_HPP
+    extern template class RTT::OutputPort< ::KDL::Frame >;
+#endif
+#ifdef ORO_INPUT_PORT_HPP
     extern template class RTT::InputPort< ::KDL::Frame >;
 #endif
 #ifdef ORO_PROPERTY_HPP
@@ -67,10 +69,13 @@ a & make_nvp("M", b.M);
     extern template class RTT::internal::ConstantDataSource< ::KDL::Rotation >;
     extern template class RTT::internal::ReferenceDataSource< ::KDL::Rotation >;
 #endif
-#ifdef ORO_INPUT_PORT_HPP
-    extern template class RTT::OutputPort< ::KDL::Rotation >;
+#ifdef ORO_CHANNEL_ELEMENT_HPP
+    extern template class RTT::base::ChannelElement< ::KDL::Rotation >;
 #endif
 #ifdef ORO_OUTPUT_PORT_HPP
+    extern template class RTT::OutputPort< ::KDL::Rotation >;
+#endif
+#ifdef ORO_INPUT_PORT_HPP
     extern template class RTT::InputPort< ::KDL::Rotation >;
 #endif
 #ifdef ORO_PROPERTY_HPP
@@ -111,10 +116,13 @@ namespace boost
     extern template class RTT::internal::ConstantDataSource< ::KDL::Twist >;
     extern template class RTT::internal::ReferenceDataSource< ::KDL::Twist >;
 #endif
-#ifdef ORO_INPUT_PORT_HPP
-    extern template class RTT::OutputPort< ::KDL::Twist >;
+#ifdef ORO_CHANNEL_ELEMENT_HPP
+    extern template class RTT::base::ChannelElement< ::KDL::Twist >;
 #endif
 #ifdef ORO_OUTPUT_PORT_HPP
+    extern template class RTT::OutputPort< ::KDL::Twist >;
+#endif
+#ifdef ORO_INPUT_PORT_HPP
     extern template class RTT::InputPort< ::KDL::Twist >;
 #endif
 #ifdef ORO_PROPERTY_HPP
@@ -150,10 +158,13 @@ a & make_nvp("rot", b.rot);
     extern template class RTT::internal::ConstantDataSource< ::KDL::Vector >;
     extern template class RTT::internal::ReferenceDataSource< ::KDL::Vector >;
 #endif
-#ifdef ORO_INPUT_PORT_HPP
-    extern template class RTT::OutputPort< ::KDL::Vector >;
+#ifdef ORO_CHANNEL_ELEMENT_HPP
+    extern template class RTT::base::ChannelElement< ::KDL::Vector >;
 #endif
 #ifdef ORO_OUTPUT_PORT_HPP
+    extern template class RTT::OutputPort< ::KDL::Vector >;
+#endif
+#ifdef ORO_INPUT_PORT_HPP
     extern template class RTT::InputPort< ::KDL::Vector >;
 #endif
 #ifdef ORO_PROPERTY_HPP
@@ -189,10 +200,13 @@ namespace boost
     extern template class RTT::internal::ConstantDataSource< ::KDL::Wrench >;
     extern template class RTT::internal::ReferenceDataSource< ::KDL::Wrench >;
 #endif
-#ifdef ORO_INPUT_PORT_HPP
-    extern template class RTT::OutputPort< ::KDL::Wrench >;
+#ifdef ORO_CHANNEL_ELEMENT_HPP
+    extern template class RTT::base::ChannelElement< ::KDL::Wrench >;
 #endif
 #ifdef ORO_OUTPUT_PORT_HPP
+    extern template class RTT::OutputPort< ::KDL::Wrench >;
+#endif
+#ifdef ORO_INPUT_PORT_HPP
     extern template class RTT::InputPort< ::KDL::Wrench >;
 #endif
 #ifdef ORO_PROPERTY_HPP
@@ -226,10 +240,13 @@ namespace boost
     extern template class RTT::internal::ConstantDataSource< ::KDL::Chain >;
     extern template class RTT::internal::ReferenceDataSource< ::KDL::Chain >;
 #endif
-#ifdef ORO_INPUT_PORT_HPP
-    extern template class RTT::OutputPort< ::KDL::Chain >;
+#ifdef ORO_CHANNEL_ELEMENT_HPP
+    extern template class RTT::base::ChannelElement< ::KDL::Chain >;
 #endif
 #ifdef ORO_OUTPUT_PORT_HPP
+    extern template class RTT::OutputPort< ::KDL::Chain >;
+#endif
+#ifdef ORO_INPUT_PORT_HPP
     extern template class RTT::InputPort< ::KDL::Chain >;
 #endif
 #ifdef ORO_PROPERTY_HPP
@@ -259,10 +276,13 @@ namespace boost
     extern template class RTT::internal::ConstantDataSource< ::KDL::Joint >;
     extern template class RTT::internal::ReferenceDataSource< ::KDL::Joint >;
 #endif
-#ifdef ORO_INPUT_PORT_HPP
-    extern template class RTT::OutputPort< ::KDL::Joint >;
+#ifdef ORO_CHANNEL_ELEMENT_HPP
+    extern template class RTT::base::ChannelElement< ::KDL::Joint >;
 #endif
 #ifdef ORO_OUTPUT_PORT_HPP
+    extern template class RTT::OutputPort< ::KDL::Joint >;
+#endif
+#ifdef ORO_INPUT_PORT_HPP
     extern template class RTT::InputPort< ::KDL::Joint >;
 #endif
 #ifdef ORO_PROPERTY_HPP
@@ -292,10 +312,13 @@ namespace boost
     extern template class RTT::internal::ConstantDataSource< ::KDL::Segment >;
     extern template class RTT::internal::ReferenceDataSource< ::KDL::Segment >;
 #endif
-#ifdef ORO_INPUT_PORT_HPP
-    extern template class RTT::OutputPort< ::KDL::Segment >;
+#ifdef ORO_CHANNEL_ELEMENT_HPP
+    extern template class RTT::base::ChannelElement< ::KDL::Segment >;
 #endif
 #ifdef ORO_OUTPUT_PORT_HPP
+    extern template class RTT::OutputPort< ::KDL::Segment >;
+#endif
+#ifdef ORO_INPUT_PORT_HPP
     extern template class RTT::InputPort< ::KDL::Segment >;
 #endif
 #ifdef ORO_PROPERTY_HPP
@@ -324,10 +347,13 @@ namespace boost
     extern template class RTT::internal::ConstantDataSource< ::KDL::Jacobian >;
     extern template class RTT::internal::ReferenceDataSource< ::KDL::Jacobian >;
 #endif
-#ifdef ORO_INPUT_PORT_HPP
-    extern template class RTT::OutputPort< ::KDL::Jacobian >;
+#ifdef ORO_CHANNEL_ELEMENT_HPP
+    extern template class RTT::base::ChannelElement< ::KDL::Jacobian >;
 #endif
 #ifdef ORO_OUTPUT_PORT_HPP
+    extern template class RTT::OutputPort< ::KDL::Jacobian >;
+#endif
+#ifdef ORO_INPUT_PORT_HPP
     extern template class RTT::InputPort< ::KDL::Jacobian >;
 #endif
 #ifdef ORO_PROPERTY_HPP
@@ -357,10 +383,13 @@ namespace boost
     extern template class RTT::internal::ConstantDataSource< ::KDL::JntArray >;
     extern template class RTT::internal::ReferenceDataSource< ::KDL::JntArray >;
 #endif
-#ifdef ORO_INPUT_PORT_HPP
-    extern template class RTT::OutputPort< ::KDL::JntArray >;
+#ifdef ORO_CHANNEL_ELEMENT_HPP
+    extern template class RTT::base::ChannelElement< ::KDL::JntArray >;
 #endif
 #ifdef ORO_OUTPUT_PORT_HPP
+    extern template class RTT::OutputPort< ::KDL::JntArray >;
+#endif
+#ifdef ORO_INPUT_PORT_HPP
     extern template class RTT::InputPort< ::KDL::JntArray >;
 #endif
 #ifdef ORO_PROPERTY_HPP
@@ -396,10 +425,13 @@ namespace boost
     extern template class RTT::internal::ConstantDataSource< std::vector<KDL::Rotation> >;
     extern template class RTT::internal::ReferenceDataSource< std::vector<KDL::Rotation> >;
 #endif
-#ifdef ORO_INPUT_PORT_HPP
-    extern template class RTT::OutputPort< std::vector<KDL::Rotation> >;
+#ifdef ORO_CHANNEL_ELEMENT_HPP
+    extern template class RTT::base::ChannelElement< std::vector<KDL::Rotation> >;
 #endif
 #ifdef ORO_OUTPUT_PORT_HPP
+    extern template class RTT::OutputPort< std::vector<KDL::Rotation> >;
+#endif
+#ifdef ORO_INPUT_PORT_HPP
     extern template class RTT::InputPort< std::vector<KDL::Rotation> >;
 #endif
 #ifdef ORO_PROPERTY_HPP
@@ -433,10 +465,13 @@ namespace boost
     extern template class RTT::internal::ConstantDataSource< std::vector<KDL::Vector> >;
     extern template class RTT::internal::ReferenceDataSource< std::vector<KDL::Vector> >;
 #endif
-#ifdef ORO_INPUT_PORT_HPP
-    extern template class RTT::OutputPort< std::vector<KDL::Vector> >;
+#ifdef ORO_CHANNEL_ELEMENT_HPP
+    extern template class RTT::base::ChannelElement< std::vector<KDL::Vector> >;
 #endif
 #ifdef ORO_OUTPUT_PORT_HPP
+    extern template class RTT::OutputPort< std::vector<KDL::Vector> >;
+#endif
+#ifdef ORO_INPUT_PORT_HPP
     extern template class RTT::InputPort< std::vector<KDL::Vector> >;
 #endif
 #ifdef ORO_PROPERTY_HPP
@@ -471,10 +506,13 @@ namespace boost
     extern template class RTT::internal::ConstantDataSource< std::vector<KDL::Frame> >;
     extern template class RTT::internal::ReferenceDataSource< std::vector<KDL::Frame> >;
 #endif
-#ifdef ORO_INPUT_PORT_HPP
-    extern template class RTT::OutputPort< std::vector<KDL::Frame> >;
+#ifdef ORO_CHANNEL_ELEMENT_HPP
+    extern template class RTT::base::ChannelElement< std::vector<KDL::Frame> >;
 #endif
 #ifdef ORO_OUTPUT_PORT_HPP
+    extern template class RTT::OutputPort< std::vector<KDL::Frame> >;
+#endif
+#ifdef ORO_INPUT_PORT_HPP
     extern template class RTT::InputPort< std::vector<KDL::Frame> >;
 #endif
 #ifdef ORO_PROPERTY_HPP
@@ -509,10 +547,13 @@ namespace boost
     extern template class RTT::internal::ConstantDataSource< std::vector<KDL::Twist> >;
     extern template class RTT::internal::ReferenceDataSource< std::vector<KDL::Twist> >;
 #endif
-#ifdef ORO_INPUT_PORT_HPP
-    extern template class RTT::OutputPort< std::vector<KDL::Twist> >;
+#ifdef ORO_CHANNEL_ELEMENT_HPP
+    extern template class RTT::base::ChannelElement< std::vector<KDL::Twist> >;
 #endif
 #ifdef ORO_OUTPUT_PORT_HPP
+    extern template class RTT::OutputPort< std::vector<KDL::Twist> >;
+#endif
+#ifdef ORO_INPUT_PORT_HPP
     extern template class RTT::InputPort< std::vector<KDL::Twist> >;
 #endif
 #ifdef ORO_PROPERTY_HPP
@@ -547,10 +588,13 @@ namespace boost
     extern template class RTT::internal::ConstantDataSource< std::vector<KDL::Wrench> >;
     extern template class RTT::internal::ReferenceDataSource< std::vector<KDL::Wrench> >;
 #endif
-#ifdef ORO_INPUT_PORT_HPP
-    extern template class RTT::OutputPort< std::vector<KDL::Wrench> >;
+#ifdef ORO_CHANNEL_ELEMENT_HPP
+    extern template class RTT::base::ChannelElement< std::vector<KDL::Wrench> >;
 #endif
 #ifdef ORO_OUTPUT_PORT_HPP
+    extern template class RTT::OutputPort< std::vector<KDL::Wrench> >;
+#endif
+#ifdef ORO_INPUT_PORT_HPP
     extern template class RTT::InputPort< std::vector<KDL::Wrench> >;
 #endif
 #ifdef ORO_PROPERTY_HPP

--- a/kdl_typekit/src/kdlTypekitVector.cpp
+++ b/kdl_typekit/src/kdlTypekitVector.cpp
@@ -1,5 +1,26 @@
 #include "kdlTypekit.hpp"
 
+template class RTT::internal::DataSource< ::KDL::Vector >;
+template class RTT::internal::AssignableDataSource< ::KDL::Vector >;
+template class RTT::internal::ValueDataSource< ::KDL::Vector >;
+template class RTT::internal::ConstantDataSource< ::KDL::Vector >;
+template class RTT::internal::ReferenceDataSource< ::KDL::Vector >;
+template class RTT::base::ChannelElement< ::KDL::Vector >;
+template class RTT::OutputPort< ::KDL::Vector >;
+template class RTT::InputPort< ::KDL::Vector >;
+template class RTT::Property< ::KDL::Vector >;
+template class RTT::Attribute< ::KDL::Vector >;
+template class RTT::internal::DataSource< std::vector<KDL::Vector> >;
+template class RTT::internal::AssignableDataSource< std::vector<KDL::Vector> >;
+template class RTT::internal::ValueDataSource< std::vector<KDL::Vector> >;
+template class RTT::internal::ConstantDataSource< std::vector<KDL::Vector> >;
+template class RTT::internal::ReferenceDataSource< std::vector<KDL::Vector> >;
+template class RTT::base::ChannelElement< std::vector<KDL::Vector> >;
+template class RTT::OutputPort< std::vector<KDL::Vector> >;
+template class RTT::InputPort< std::vector<KDL::Vector> >;
+template class RTT::Property< std::vector<KDL::Vector> >;
+template class RTT::Attribute< std::vector<KDL::Vector> >;
+
 namespace KDL{
   using namespace std;
   using namespace RTT;

--- a/kdl_typekit/src/kdlTypekitVector.cpp
+++ b/kdl_typekit/src/kdlTypekitVector.cpp
@@ -5,7 +5,7 @@ namespace KDL{
   using namespace RTT;
 
   void loadVectorTypes(){
-    RTT::types::Types()->addType( new KDLTypeInfo<Vector>("KDL.Vector") );
+    RTT::types::Types()->addType( new KDLVectorTypeInfo<Vector,3>("KDL.Vector") );
     RTT::types::Types()->addType( new SequenceTypeInfo<std::vector< Vector > >("KDL.Vector[]") );
   };
 }  

--- a/kdl_typekit/src/kdlTypekitWrench.cpp
+++ b/kdl_typekit/src/kdlTypekitWrench.cpp
@@ -5,7 +5,7 @@ namespace KDL{
   using namespace RTT;
 
   void loadWrenchTypes(){
-    RTT::types::Types()->addType( new KDLTypeInfo<Wrench>("KDL.Wrench") );
+    RTT::types::Types()->addType( new KDLVectorTypeInfo<Wrench,6>("KDL.Wrench") );
     RTT::types::Types()->addType( new SequenceTypeInfo<std::vector< Wrench > >("KDL.Wrench[]") );
   };
 }  

--- a/kdl_typekit/src/kdlTypekitWrench.cpp
+++ b/kdl_typekit/src/kdlTypekitWrench.cpp
@@ -1,5 +1,26 @@
 #include "kdlTypekit.hpp"
 
+template class RTT::internal::DataSource< ::KDL::Wrench >;
+template class RTT::internal::AssignableDataSource< ::KDL::Wrench >;
+template class RTT::internal::ValueDataSource< ::KDL::Wrench >;
+template class RTT::internal::ConstantDataSource< ::KDL::Wrench >;
+template class RTT::internal::ReferenceDataSource< ::KDL::Wrench >;
+template class RTT::base::ChannelElement< KDL::Wrench >;
+template class RTT::OutputPort< ::KDL::Wrench >;
+template class RTT::InputPort< ::KDL::Wrench >;
+template class RTT::Property< ::KDL::Wrench >;
+template class RTT::Attribute< ::KDL::Wrench >;
+template class RTT::internal::DataSource< std::vector<KDL::Wrench> >;
+template class RTT::internal::AssignableDataSource< std::vector<KDL::Wrench> >;
+template class RTT::internal::ValueDataSource< std::vector<KDL::Wrench> >;
+template class RTT::internal::ConstantDataSource< std::vector<KDL::Wrench> >;
+template class RTT::internal::ReferenceDataSource< std::vector<KDL::Wrench> >;
+template class RTT::base::ChannelElement< std::vector<KDL::Wrench> >;
+template class RTT::OutputPort< std::vector<KDL::Wrench> >;
+template class RTT::InputPort< std::vector<KDL::Wrench> >;
+template class RTT::Property< std::vector<KDL::Wrench> >;
+template class RTT::Attribute< std::vector<KDL::Wrench> >;
+
 namespace KDL{
   using namespace std;
   using namespace RTT;

--- a/kdl_typekit/test/CMakeLists.txt
+++ b/kdl_typekit/test/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 2.8.3)
 
-find_package(OROCOS-RTT REQUIRED rtt-marshalling)
+find_package(OROCOS-RTT REQUIRED rtt-marshalling rtt-scripting)
 
 orocos_use_package(ocl-deployment)
 include_directories(${ocl-deployment_INCLUDE_DIRS} ${PROJECT_SOURCE_DIR}/src)
@@ -14,13 +14,20 @@ target_link_libraries(typekit_test
   ${PROJECT_NAME}
   pthread)
 
+catkin_add_gtest(typekit_scripting_test typekit_scripting_test.cpp WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(typekit_scripting_test 
+  ${orocos_kdl_LIBRARIES}
+  ${OROCOS-RTT_RTT_LIBRARIES}
+  ${OROCOS-RTT_RTT-SCRIPTING_LIBRARY} 
+  ${PROJECT_NAME}
+  pthread)
+
 if(OROCOS-RTT_CORBA_FOUND)
 catkin_add_gtest(typekit_corba_test typekit_corba_test.cpp WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(typekit_corba_test 
   ${orocos_kdl_LIBRARIES}
   ${USE_OROCOS_LIBRARIES}
   ${OROCOS-RTT_RTT_LIBRARIES}
-  ${OROCOS-RTT_RTT-MARSHALLING_LIBRARY}
   ${OROCOS-RTT_CORBA_LIBRARIES}
   ${PROJECT_NAME}
   pthread)

--- a/kdl_typekit/test/typekit-test.ops
+++ b/kdl_typekit/test/typekit-test.ops
@@ -1,0 +1,42 @@
+program vector_test {
+ var KDL.Vector v1;
+ var KDL.Vector v2;
+ var KDL.Vector v3;
+ 
+ //Test accessors
+ v1.X = 1.
+ v1.Y = 2.
+ v1.Z = 3.
+ v2[0] = 10.
+ v2[1] = 20.
+ v2[2] = 30.
+ if ( v1[0] != 1.) then throw()
+ if ( v1[1] != 2.) then throw()
+ if ( v1[2] != 3.) then throw()
+ if ( v1[3] != 0.) then throw()
+ if ( v1[-1] != 0.) then throw()
+ 
+ if ( v2.X != 10.) then throw()
+ if ( v2.Y != 20.) then throw()
+ if ( v2.Z != 30.) then throw()
+ 
+ //Test operations
+ v3 = v2 + v1
+ if ( v3 != v2 + v1) then throw()
+ if ( v2 == v3 ) then throw()
+ v3 = v2 - v1
+ if ( v3 != v2 - v1) then throw()
+ v3 = v1 * 2
+ if ( v3[0] != v1[0] * 2) then throw()
+ if ( v3[1] != v1[1] * 2) then throw()
+ if ( v3[2] != v1[2] * 2) then throw()
+ v3 = v1 / 2
+ if ( v3[0] != v1[0] / 2) then throw()
+ if ( v3[1] != v1[1] / 2) then throw()
+ if ( v3[2] != v1[2] / 2) then throw()
+ 
+}
+
+program rotation_test {
+ var KDL.Rotation r;
+ }

--- a/kdl_typekit/test/typekit-test.ops
+++ b/kdl_typekit/test/typekit-test.ops
@@ -2,6 +2,9 @@ program vector_test {
  var KDL.Vector v1;
  var KDL.Vector v2;
  var KDL.Vector v3;
+
+ //Test constructors
+ v1 = KDL.Vector(0., 0., 0.)
  
  //Test accessors
  v1.X = 1.
@@ -34,9 +37,12 @@ program vector_test {
  if ( v3[0] != v1[0] / 2) then throw()
  if ( v3[1] != v1[1] / 2) then throw()
  if ( v3[2] != v1[2] / 2) then throw()
- 
 }
 
 program rotation_test {
  var KDL.Rotation r;
- }
+
+ //Test constructors
+ r = KDL.Rotation(0.1, 0.2, 0.3)
+ r = KDL.Rotation(KDL.Vector(1., 2., 3.), .5)
+}

--- a/kdl_typekit/test/typekit_scripting_test.cpp
+++ b/kdl_typekit/test/typekit_scripting_test.cpp
@@ -1,0 +1,53 @@
+#include <gtest/gtest.h>
+#include <rtt/os/main.h>
+#include <rtt/plugin/PluginLoader.hpp>
+#include <rtt/scripting/ScriptingService.hpp>
+#include <rtt/TaskContext.hpp>
+
+
+void throw_function() {
+    throw std::exception();
+}
+
+class KDLPluginScriptingTest : public testing::Test {
+
+protected:
+    KDLPluginScriptingTest():
+        tc("test")
+    {
+    }
+
+    virtual void SetUp() {
+        ASSERT_TRUE(RTT::plugin::PluginLoader::Instance()->loadTypekit("kdl_typekit",RTT::plugin::PluginLoader::Instance()->getPluginPath())) << "Failed to load kdl typekit";
+        ASSERT_TRUE(tc.loadService("scripting")) << "Unable to load scripting service";
+        scripting = boost::dynamic_pointer_cast<RTT::scripting::ScriptingService>( tc.provides()->getService("scripting") );
+        ASSERT_TRUE(scripting) << "Failed to get loaded scripting service";
+
+        tc.addOperation("throw",&throw_function);
+        tc.setPeriod(0.01);
+        ASSERT_TRUE(scripting->loadPrograms("./typekit-test.ops",false)) << "Failed to load test program";
+        ASSERT_TRUE(tc.start()) << "Failed to start TaskContext";
+    }
+    virtual void TearDown() {
+    }
+    
+    RTT::TaskContext tc;
+    RTT::scripting::ScriptingService::shared_ptr scripting;
+};
+
+TEST_F(KDLPluginScriptingTest, ScriptTest) {
+    RTT::scripting::ProgramInterfacePtr program = scripting->getProgram("vector_test");
+    ASSERT_TRUE(program) << "Failed to get program";
+    ASSERT_TRUE(program->start());
+    while(program->isRunning()) {;
+        ASSERT_FALSE(program->inError()) << "program failed on line " << program->getLineNumber();
+        usleep(1000);
+    }
+    ASSERT_FALSE(program->inError()) << "Failed on line " << program->getLineNumber();
+}
+
+int ORO_main(int argc, char **argv){
+    testing::InitGoogleTest(&argc,argv);
+    return RUN_ALL_TESTS();
+}
+

--- a/kdl_typekit/test/typekit_scripting_test.cpp
+++ b/kdl_typekit/test/typekit_scripting_test.cpp
@@ -36,14 +36,18 @@ protected:
 };
 
 TEST_F(KDLPluginScriptingTest, ScriptTest) {
-    RTT::scripting::ProgramInterfacePtr program = scripting->getProgram("vector_test");
-    ASSERT_TRUE(program) << "Failed to get program";
-    ASSERT_TRUE(program->start());
-    while(program->isRunning()) {;
-        ASSERT_FALSE(program->inError()) << "program failed on line " << program->getLineNumber();
-        usleep(1000);
+    std::vector<std::string> programs = scripting->getProgramList();
+
+    for(std::vector<std::string>::const_iterator it = programs.begin(); it != programs.end(); ++it) {
+        RTT::scripting::ProgramInterfacePtr program = scripting->getProgram(*it);
+        ASSERT_TRUE(program) << "Failed to get program " << *it;
+        ASSERT_TRUE(program->start());
+        while(program->isRunning()) {
+            ASSERT_FALSE(program->inError()) << "Program " << *it << " failed on line " << program->getLineNumber();
+            usleep(1000);
+        }
+        ASSERT_FALSE(program->inError()) << "Program " << *it << " failed on line " << program->getLineNumber();
     }
-    ASSERT_FALSE(program->inError()) << "Failed on line " << program->getLineNumber();
 }
 
 int ORO_main(int argc, char **argv){

--- a/rtt_geometry/CHANGELOG.rst
+++ b/rtt_geometry/CHANGELOG.rst
@@ -2,5 +2,22 @@
 Changelog for package rtt_geometry
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+2.8.1 (2015-07-21)
+------------------
+* Merge pull request `#14 <https://github.com/orocos/rtt_geometry/issues/14>`_ from orocos/fix/extern_template_explicit_instantiation
+  kdl_typekit: fix extern declare, explicit instantiate mechanism
+* Merge pull request `#13 <https://github.com/orocos/rtt_geometry/issues/13>`_ from orocos/introduce_index_operator_for_vector_wrench_twist
+  kdl_typekit: added index operators for Vector, Wrench and Twist
+* Merge remote-tracking branch 'origin/indigo-devel' into introduce_index_operator_for_vector_wrench_twist
+* kdl_typekit: fix extern declare, explicit instantiate mechanism
+  We forgot the explicit instantiation, also added the channelelement type
+* kdl_typekit: Incomplete but working unittest for kdl typekit scripting
+  Use indigo from now on.
+* kdl_typekit: added index operators for Vector, Wrench and Twist
+* replace lua based corba typekit test with c++ based gtest
+* Install typekit header additionally as Types.hpp to be consistent with orogen generated typekits
+* eigen_typekit: unified maintainer name in package.xml across orocos-toolchain and related packages
+
 2.8.0 (2015-01-23)
 ------------------
+ * Initial release

--- a/rtt_geometry/package.xml
+++ b/rtt_geometry/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>rtt_geometry</name>
-  <version>2.8.0</version>
+  <version>2.8.1</version>
   <description>
     This metapackage contains tools for integrating the Orocos Kinematics and
     Dynamics Library (KDL) with the Orocos Toolchain and Real-Time Toolkit


### PR DESCRIPTION
Follow up of orocos/rtt_geometry#15:
- merged with origin/indigo-devel (required for the new kdl_typekit scripting test added in https://github.com/snrkiwi/rtt_geometry/commit/b7a361da0c92104b747216430da5e94c8a5ae971)
- added tests for the constructors of KDL.Vector and KDL.Rotation including the new angle-axis constructor
